### PR TITLE
Актуализированы ссылки на issue forms

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,13 +6,13 @@ github-issues:
     state: open
     lables:
       - bug
-    template: bug_report.md
+    template: bug.yml
   idea:
     title: Идеи и предложения
     state: open
     lables:
       - idea
-    template: idea.md
+    template: idea.yml
 ---
 
 > Telepost помогает администраторам каналов сократить рутинную работу и сосредоточиться на производстве качественного контента. Здесь есть отложенные посты, визуальный редактор, совместная работа и многое другое. А главное, совершенно **бесплатно**!


### PR DESCRIPTION
После перевода шаблонов тикетов (Telepost-me/support#55) на [Github Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) были обновлены ссылки на главной странице.