### PR TITLE
Удаление статического сайта и метаданных

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Cleanup: remove static site folder and metadata..."
+rm -rf _site .jekyll-metadata
+
+echo "Launch site in Docker container..."
 docker run --rm \
     --volume="$PWD:/srv/jekyll" \
     -p 4000:4000 \


### PR DESCRIPTION
Иногда папка со статической версией сайта, оставшаяся с прошлого раза, вызывает проблемы: ошибка
```
chown: Permission denied
```
Также файл `.jekyll-metadata` может приводить к различным артефактам.