### PR TITLE
Github API: 100 issues per page

### DIFF
--- a/assets/github-issues.js
+++ b/assets/github-issues.js
@@ -4,7 +4,7 @@ function githubIssues(username, repo, state, labels, title) {
 
   $(document).ready(function() {
     $.getJSON(
-    	`https://api.github.com/repos/${username}/${repo}/issues?state=${state}&labels=${labels.join(',')}`)
+    	`https://api.github.com/repos/${username}/${repo}/issues?per_page=100&state=${state}&labels=${labels.join(',')}`)
       .done(
         function(issues) {
         $(`div.${labels.join('.')}`)


### PR DESCRIPTION
Проблема: сейчас на главной в списках Github Issues показываются не все записи.

Это происходит потому, что по умолчанию Github API возвращает 30 элементов за раз (пагинация), для получения след. элементов нужно использовать параметр `page=2` для указания страницы, либо поднять лимит кол-ва элементов на странице: `per_page=100` (вернет 100 элементов на каждой странице).

https://stackoverflow.com/questions/30656761/github-search-api-only-return-30-results