### PR TITLE
Добавлено описание про spoiler для веб-версии

### DIFF
--- a/_posts/2023-02-23-spoiler.md
+++ b/_posts/2023-02-23-spoiler.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Скрытый текст (spoilers)
+title: Скрытый текст (spoiler)
 excerpt: Как сделать текст/медия скрытым в формате Native, Markdown, HTML
 lang: ru
 tags: [Инструкция]
@@ -33,8 +33,13 @@ category: FAQ
     <span class="tg-spoiler">спойлер</span>
     ```
 
-* в веб-версии — выделите текст и отформатируете как на скриншоте ниже:
-  ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+* в веб-версии:
 
-  Текст будет виден, но подсвечиваться желтым цветом:
-  ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+  * в **обычном режиме редактора** — выделите текст и отформатируете как на скриншоте ниже:
+    ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+
+    Текст будет виден, но подсвечиваться желтым цветом:
+    ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+
+  * в **режиме редактора Markdown** — оберните в парные символы `||`:
+    ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)

--- a/en/_posts/2023-02-23-spoiler.md
+++ b/en/_posts/2023-02-23-spoiler.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Hidden text (spoilers)
+title: Hidden text (spoiler)
 excerpt: How to make text/media spoiler in Native mode, Markdown, HTML
 lang: en
 tags: [Instruction]
@@ -33,8 +33,13 @@ You can [make text/media hidden](https://telegram.org/blog/reactions-spoilers-tr
     <span class="tg-spoiler">spoiler</span>
     ```
 
-* in Web UI — select the text and formatting and format as in the screenshot below:
-  ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+* in Web UI:
 
-  Text will be visible, but highlighted in yellow:
-  ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+  * **usual mode editor** — select the text and formatting and format as in the screenshot below:
+    ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+
+    Text will be visible, but highlighted in yellow:
+    ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+
+  * **Markdown mode editor** — wrap in paired characters `||`:
+    ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)


### PR DESCRIPTION
После добавления поддержки спойлера (скрытый текст/медиа — spoiler) в рамках https://github.com/Telepost-me/support/issues/81 сделано описание, как этим пользоваться в веб-версии/боте.