### PR TITLE
Инструкция про спойлер разбита по заголовкам

### DIFF
--- a/_posts/2023-02-23-spoiler.md
+++ b/_posts/2023-02-23-spoiler.md
@@ -7,39 +7,43 @@ tags: [Инструкция]
 category: FAQ
 ---
 
-[Сделать текст/медия скрытым](https://telegram.org/blog/reactions-spoilers-translations/ru#skritii-tekst) (показывается при нажатии — spoiler) в Телепосте можно в нескольких вариантах форматирования:
+[Сделать текст/медия скрытым](https://telegram.org/blog/reactions-spoilers-translations/ru#skritii-tekst) (показывается при нажатии — spoiler) в Телепосте можно в нескольких вариантах форматирования: Native, Markdown, HTML.
 
-* в боте в режимах:
+## Бот
 
-  * **[Native](2022-04-24-native-mode.md)** — просто выделите текст/медиа и во всплывающем меню выберите <kbd>Форматирование</kbd> → <kbd>Скрытый</kbd>:
-    ![image](https://user-images.githubusercontent.com/24430718/220902300-12d4e906-9a61-46e1-8351-dc9e933a4dab.jpg)
-    ![image](https://user-images.githubusercontent.com/24430718/220902421-bbe8b785-1f02-439e-a366-d03f1cb672b4.jpg)
+В боте спройлер поддерживается во всех режимах:
 
-  * **[Markdown](https://core.telegram.org/bots/api#markdownv2-style)** — оберните в парные символы `||`:
+* **[Native](2022-04-24-native-mode.md)** — просто выделите текст/медиа и во всплывающем меню выберите <kbd>Форматирование</kbd> → <kbd>Скрытый</kbd>:
+  ![image](https://user-images.githubusercontent.com/24430718/220902300-12d4e906-9a61-46e1-8351-dc9e933a4dab.jpg)
+  ![image](https://user-images.githubusercontent.com/24430718/220902421-bbe8b785-1f02-439e-a366-d03f1cb672b4.jpg)
 
-    ```text
-    Дальше будет ||спойлер||
-    ```
+* **[Markdown](https://core.telegram.org/bots/api#markdownv2-style)** — оберните в парные символы `||`:
 
-  * **[HTML](https://core.telegram.org/bots/api#html-style)** — оберните в тег `<tg-spoiler></tg-spoiler>` или `<span class="tg-spoiler"></span>`:
+  ```text
+  Дальше будет ||спойлер||
+  ```
 
-    ```html
-    <tg-spoiler>спойлер</tg-spoiler>
-    ```
+* **[HTML](https://core.telegram.org/bots/api#html-style)** — оберните в тег `<tg-spoiler></tg-spoiler>` или `<span class="tg-spoiler"></span>`:
 
-    или
+  ```html
+  <tg-spoiler>спойлер</tg-spoiler>
+  ```
 
-    ```html
-    <span class="tg-spoiler">спойлер</span>
-    ```
+  или
 
-* в веб-версии:
+  ```html
+  <span class="tg-spoiler">спойлер</span>
+  ```
 
-  * в **обычном режиме редактора** — выделите текст и отформатируете как на скриншоте ниже:
-    ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+## Веб-версия
 
-    Текст будет виден, но подсвечиваться желтым цветом:
-    ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+В веб-версии сделать спойлер можно следующими способами:
 
-  * в **режиме редактора Markdown** — оберните в парные символы `||`:
-    ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)
+* в **обычном режиме редактора** — выделите текст и отформатируете как на скриншоте ниже:
+  ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+
+  Текст будет виден, но подсвечиваться желтым цветом:
+  ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
+
+* в **режиме редактора Markdown** — оберните в парные символы `||`:
+  ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)

--- a/en/_posts/2023-02-23-spoiler.md
+++ b/en/_posts/2023-02-23-spoiler.md
@@ -9,37 +9,41 @@ category: FAQ
 
 You can [make text/media hidden](https://telegram.org/blog/reactions-spoilers-translations/#spoilers) (shown when clicked — spoiler) in Telepost in several formatting options:
 
-* in bot — modes:
+## Bot
 
-  * **[Native](2022-04-24-native-mode.md)** — just select the text/media and choose <kbd>Format</kbd> → <kbd>Spoiler</kbd> from the pop-up menu:
-    ![image](https://user-images.githubusercontent.com/24430718/220902300-12d4e906-9a61-46e1-8351-dc9e933a4dab.jpg)
-    ![image](https://user-images.githubusercontent.com/24430718/220902421-bbe8b785-1f02-439e-a366-d03f1cb672b4.jpg)
+In the bot, the spoiler is supported in all modes:
 
-  * **[Markdown](https://core.telegram.org/bots/api#markdownv2-style)** — wrap in paired characters `||`:
+* **[Native](2022-04-24-native-mode.md)** — just select the text/media and choose <kbd>Format</kbd> → <kbd>Spoiler</kbd> from the pop-up menu:
+  ![image](https://user-images.githubusercontent.com/24430718/220902300-12d4e906-9a61-46e1-8351-dc9e933a4dab.jpg)
+  ![image](https://user-images.githubusercontent.com/24430718/220902421-bbe8b785-1f02-439e-a366-d03f1cb672b4.jpg)
 
-    ```text
-    Next will be ||spoiler||
-    ```
+* **[Markdown](https://core.telegram.org/bots/api#markdownv2-style)** — wrap in paired characters `||`:
 
-  * **[HTML](https://core.telegram.org/bots/api#html-style)** — wrap in tag `<tg-spoiler></tg-spoiler>` or `<span class="tg-spoiler"></span>`:
+  ```text
+  Next will be ||spoiler||
+  ```
 
-    ```html
-    <tg-spoiler>spoiler</tg-spoiler>
-    ```
+* **[HTML](https://core.telegram.org/bots/api#html-style)** — wrap in tag `<tg-spoiler></tg-spoiler>` or `<span class="tg-spoiler"></span>`:
 
-    or
+  ```html
+  <tg-spoiler>spoiler</tg-spoiler>
+  ```
 
-    ```html
-    <span class="tg-spoiler">spoiler</span>
-    ```
+  or
 
-* in Web UI:
+  ```html
+  <span class="tg-spoiler">spoiler</span>
+  ```
 
-  * **usual mode editor** — select the text and formatting and format as in the screenshot below:
-    ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+## Web UI
 
-    Text will be visible, but highlighted in yellow:
+In the web version, you can make a spoiler in the following ways:
+
+* **usual mode editor** — select the text and formatting and format as in the screenshot below:
+  ![image](https://user-images.githubusercontent.com/24430718/220900766-1d10c6f4-1255-42da-b95f-5c6e93044d7f.png)
+
+  Text will be visible, but highlighted in yellow:
     ![image](https://user-images.githubusercontent.com/24430718/220914642-03e7e20c-d612-4e1b-af6d-d295ba899058.png)
 
-  * **Markdown mode editor** — wrap in paired characters `||`:
-    ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)
+* **Markdown mode editor** — wrap in paired characters `||`:
+  ![image](https://user-images.githubusercontent.com/24430718/220951037-e234d0e3-e478-4e90-9c6d-46b0017e8bfb.png)


### PR DESCRIPTION
После добавления поддержки спойлера (скрытый текст/медиа — spoiler) в рамках https://github.com/Telepost-me/support/issues/81 сделано описание, как этим пользоваться в веб-версии/боте.

Инструкция разбита на части по заголовкам, а то списком вложенным тяжело читается.