### PR TITLE
Улучшение страницы с тегами

### DIFF
--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -4,17 +4,20 @@ layout: page
 
   <div id="archives">
   {% for tag in site.tags %}
+    {% assign tag_name = tag | first %}
+    {% assign posts_with_tag = site.tags[tag_name] | where: "lang", page.lang | sort: "title" %}
+    {% if posts_with_tag.size > 0 %}
     <div class="archive-group">
-      {% capture tag_name %}{{ tag | first }}{% endcapture %}
       <div id="#{{ tag_name | slugize }}"></div>
       <h2 class="category-head">{{ tag_name }}</h2>
       <a name="{{ tag_name | slugize }}"></a>
-      {% for post in site.tags[tag_name] %}
+      {% for post in posts_with_tag %}
       <article class="archive-item">
         <a href="{{ site.baseurl }}{{ post.url }}">{% if post.title and post.title != "" %}{{ post.title }}{% else %}{{ post.excerpt | strip_html }}{% endif %}</a>
       </article>
       {% endfor %}
     </div>
+    {% endif %}
   {% endfor %}
   </div>
 


### PR DESCRIPTION
Раньше на странице с разбивкой постов по тегам были все страницы со всеми тегами вперемешку: посты и теги на русском и английском.

Теперь всё чётенько: на странице на русском — только теги и посты на русском, на странице с английским переводом — только теги и посты на английском.